### PR TITLE
Update vcpkg to reflect vcmi 1.0 latest changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ Built and exported by [Vcpkg](https://github.com/Microsoft/vcpkg).
 * Install Vcpkg and it's dependencies.
 * Build all required packages for one or both architectures:
 ```
-vcpkg install tbb:x64-windows fuzzylite:x64-windows sdl2:x64-windows sdl2-image:x64-windows sdl2-ttf:x64-windows sdl2-mixer:x64-windows boost:x64-windows qt5:x64-windows ffmpeg:x64-windows
-vcpkg install tbb:x86-windows fuzzylite:x86-windows sdl2:x86-windows sdl2-image:x86-windows sdl2-ttf:x86-windows sdl2-mixer:x86-windows boost:x86-windows qt5:x86-windows ffmpeg:x86-windows
+vcpkg install tbb:x64-windows fuzzylite:x64-windows sdl2:x64-windows sdl2-image:x64-windows sdl2-ttf:x64-windows sdl2-mixer[mpg123]:x64-windows boost:x64-windows qt5:x64-windows ffmpeg:x64-windows luajit:x64-windows
+vcpkg install tbb:x86-windows fuzzylite:x86-windows sdl2:x86-windows sdl2-image:x86-windows sdl2-ttf:x86-windows sdl2-mixer[mpg123]:x86-windows boost:x86-windows qt5:x86-windows ffmpeg:x86-windows luajit:x86-windows
 ```
 * Export packages so 7z archive will be produced:
 ```
-vcpkg export tbb:x64-windows fuzzylite:x64-windows sdl2:x64-windows sdl2-image:x64-windows sdl2-ttf:x64-windows sdl2-mixer:x64-windows boost:x64-windows qt5:x64-windows ffmpeg:x64-windows --7zip
-vcpkg export tbb:x86-windows fuzzylite:x86-windows sdl2:x86-windows sdl2-image:x86-windows sdl2-ttf:x86-windows sdl2-mixer:x86-windows boost:x86-windows qt5:x86-windows ffmpeg:x86-windows --7zip
+vcpkg export tbb:x64-windows fuzzylite:x64-windows sdl2:x64-windows sdl2-image:x64-windows sdl2-ttf:x64-windows sdl2-mixer:x64-windows boost:x64-windows qt5-base:x64-windows ffmpeg:x64-windows luajit:x64-windows --7zip
+vcpkg export tbb:x86-windows fuzzylite:x86-windows sdl2:x86-windows sdl2-image:x86-windows sdl2-ttf:x86-windows sdl2-mixer:x86-windows boost:x86-windows qt5-base:x86-windows ffmpeg:x86-windows luajit:x86-windows --7zip
 ```
 * Rename archives appropriately. Bevare that Vcpkg use newest MSVC available by default, but [it's possible to enforce certain version with custom triplet](https://github.com/Microsoft/vcpkg/issues/1207).  
 ```


### PR DESCRIPTION
I am going to update all packages except QT and boost (the last failed to build so we will continue using the one from previous release)
- SDL_mixer will use mpg123 feature for mp3
- ffmpeg updated to play video correctly (so some artifacts still present)