### PR TITLE
Update Vcpkg dependencies

### DIFF
--- a/.github/workflows/rebuildDependencies.yml
+++ b/.github/workflows/rebuildDependencies.yml
@@ -17,15 +17,20 @@ jobs:
           - platform: msvc-x64
             triplet: x64-windows
             runner: windows-latest
-            overlay: vcmi-overlay-boost
+            toolset: v142
+            overlays: "--overlay-ports=vcmi-overlay-boost --overlay-ports=vcmi-overlay-tbb"
+
           - platform: msvc-x86
             triplet: x86-windows
             runner: windows-latest
-            overlay: vcmi-overlay-boost
+            toolset: v142
+            overlays: "--overlay-ports=vcmi-overlay-boost --overlay-ports=vcmi-overlay-tbb"
+
           - platform: msvc-arm64
             triplet: arm64-windows
             runner: windows-11-arm
-            overlay: vcmi-overlay-yasm
+            toolset: v143
+            overlays: "--overlay-ports=vcmi-overlay-yasm"
 
     runs-on: ${{ matrix.runner }}
     defaults:
@@ -33,26 +38,19 @@ jobs:
         shell: bash
 
     steps:
-      # Use latest vcpkg for x64/x86
+      # Use latest vcpkg for x86/x64/ARM64
       - name: Checkout vcpkg (latest)
         uses: actions/checkout@v4
         with:
           repository: 'microsoft/vcpkg'
           ref: master
 
-      - name: Prepare overlays (Boost + YASM)
+      - name: Prepare overlays (YASM)
+        if: matrix.triplet == 'arm64-windows'
         run: |
-          mkdir -p vcmi-overlay-boost vcmi-overlay-yasm
+          mkdir -p vcmi-overlay-yasm
 
-          # Boost overlay (Win7 fix)
-          # Commit before addition of boost filesystem 1.87 that removes Win7 support:
-          # https://github.com/microsoft/vcpkg/pull/42678
-          # Commit: ec12d917a85839741f8345905f71b3e7f56d9ddc
-          git fetch origin ec12d917a85839741f8345905f71b3e7f56d9ddc
-          git checkout ec12d917a85839741f8345905f71b3e7f56d9ddc
-          cp -r ports/boost* vcmi-overlay-boost/
-
-          # YASM overlay (ARM64 fix)
+          # YASM overlay
           # Commit before changes to yasm package which seem to break ARM builds:
           # https://github.com/microsoft/vcpkg/pull/45856
           # Commit: 94a9df6990e426ec3fff1a4ba20016da4aafea70
@@ -60,7 +58,28 @@ jobs:
           git checkout 94a9df6990e426ec3fff1a4ba20016da4aafea70
           cp -r ports/yasm* vcmi-overlay-yasm/
 
-          # Switch back to master for the rest of the ports
+          git checkout master
+
+      - name: Prepare overlays (Boost + TBB)
+        if: matrix.triplet == 'x64-windows' || matrix.triplet == 'x86-windows'
+        run: |
+          mkdir -p vcmi-overlay-boost vcmi-overlay-tbb
+
+          # Boost overlay
+          # Commit before addition of boost filesystem 1.87 that removes Win7 support:
+          # https://github.com/microsoft/vcpkg/pull/42678
+          # Commit: ec12d917a85839741f8345905f71b3e7f56d9ddc
+          git fetch origin ec12d917a85839741f8345905f71b3e7f56d9ddc
+          git checkout ec12d917a85839741f8345905f71b3e7f56d9ddc
+          cp -r ports/boost* vcmi-overlay-boost/
+
+          # TBB overlay
+          # Commit before update to 2022.1
+          # https://github.com/microsoft/vcpkg/pull/45086
+          # Commit: ae88776c2ec0ac719c0460b1bedf0dd3b11b374c
+          git fetch origin ae88776c2ec0ac719c0460b1bedf0dd3b11b374c
+          git checkout ae88776c2ec0ac719c0460b1bedf0dd3b11b374c
+          cp -r ports/tbb* vcmi-overlay-tbb/
           git checkout master
 
       # NOTE: disabling debug for all triplets, so 64 host / 32 guest won't build debug version of 64-bit tools
@@ -70,6 +89,10 @@ jobs:
           echo 'set(VCPKG_BUILD_TYPE release)' >>triplets/x64-windows.cmake
           echo 'set(VCPKG_BUILD_TYPE release)' >>triplets/x86-windows.cmake
           echo 'set(VCPKG_BUILD_TYPE release)' >>triplets/arm64-windows.cmake
+          
+      - name: Force toolset version
+        run: |
+          echo 'set(VCPKG_PLATFORM_TOOLSET ${{ matrix.toolset }})' >> triplets/${{ matrix.triplet }}.cmake
 
       - name: Enable Windows 7 targeting (x86/x64)
         if: matrix.triplet == 'x64-windows' || matrix.triplet == 'x86-windows'
@@ -82,8 +105,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          ./vcpkg.exe install yasm --triplet "${{ matrix.triplet }}" --overlay-ports=${{ matrix.overlay }}
-      
+          ./vcpkg.exe install yasm --triplet "${{ matrix.triplet }}" ${{ matrix.overlays }}
+
           ./vcpkg.exe install \
             tbb fuzzylite sdl2 sdl2-image sdl2-ttf sdl2-mixer[core,mpg123] \
             qt5-base qt5-tools \
@@ -91,9 +114,9 @@ jobs:
             boost-filesystem boost-system boost-thread boost-program-options boost-locale \
             boost-iostreams boost-headers boost-foreach boost-format boost-crc boost-logic \
             boost-multi-array boost-ptr-container boost-heap boost-bimap boost-asio \
-            boost-stacktrace boost-assign boost-geometry boost-uuid boost-process \
+            boost-stacktrace boost-assign boost-geometry boost-uuid boost-process minizip \
             --triplet "${{ matrix.triplet }}" \
-            --overlay-ports=${{ matrix.overlay }}
+            ${{ matrix.overlays }}
 
       - name: Export packages
         run: |
@@ -102,9 +125,9 @@ jobs:
             boost-filesystem boost-system boost-thread boost-program-options boost-locale \
             boost-iostreams boost-headers boost-foreach boost-format boost-crc boost-logic \
             boost-multi-array boost-ptr-container boost-heap boost-bimap boost-asio \
-            boost-stacktrace boost-assign boost-geometry boost-uuid boost-process \
+            boost-stacktrace boost-assign boost-geometry boost-uuid boost-process minizip \
             --raw --triplet "${{ matrix.triplet }}" \
-            --overlay-ports=${{ matrix.overlay }} \
+            ${{ matrix.overlays }} \
             --output=result/vcpkg
 
       - name: Trim pdb files


### PR DESCRIPTION
1) Added minizip
2) Added overlay for TBB, otherwise dependencies for Windows 7 can be compiled
3) v142 toolset is used for x86 and x64, for ARM64 v143